### PR TITLE
Enable the "core" mod by default

### DIFF
--- a/gameinfo.gi
+++ b/gameinfo.gi
@@ -144,6 +144,7 @@
 	{
 		"Engine"	"Source 2"
 		"ToolsDir"	"../sdktools"	// NOTE: Default Tools path. This is relative to the mod path.
+		"ShowCoreMod"	"1"	
 	}
 	
 	Hammer


### PR DESCRIPTION
This enables users to actually utilize the steamVR resources, which is
necessary for a lot of things like lighting etc.