### PR TITLE
Add missing attributes to prop_handpose

### DIFF
--- a/hlvr.fgd
+++ b/hlvr.fgd
@@ -523,7 +523,7 @@
 	input Disabled(void): ""
 ]
 
-@PointClass base(Targetname) editormodel("models/props/max/handposes/handpose_grabpole.vmdl") = prop_handpose : "An area where player hands can be placed to grab item"
+@PointClass base(Targetname, Parentname, Global, Studiomodel, Glow) editormodel("models/props/max/handposes/handpose_grabpole.vmdl") = prop_handpose : "Forces hand into a specific pose"
 [
 	DistanceMin(float): "Minimum Distance": 4: "Minimum grabbable distance"
 	DistanceMax(float): "Maximum Distance": 6: "Maximum grabbable distance"


### PR DESCRIPTION
This is needed to fix my button prefab on discord.

Currently prop_handpose is missing basic attributes like parenting causing valued to update parent references.